### PR TITLE
Fix encoding error

### DIFF
--- a/picobase64.h
+++ b/picobase64.h
@@ -188,7 +188,7 @@ size_t GetDecodeExpectedLen(size_t inLen) noexcept
 auto b64encode(picostr bytes) noexcept
 {
 #ifdef __cplusplus
-    auto strLen = GetEncodeLen(std::string_view(bytes).length());
+    auto strLen = bytes.length();
 #else
     uint32_t eLen = GetEncodeLen(strlen(bytes));
 #endif


### PR DESCRIPTION
Function GetEncodeLen called twice resulting in wrong length parameter for encoding routine